### PR TITLE
added_slug_type_and_archive_for_plans_crud

### DIFF
--- a/application/repositories/store.go
+++ b/application/repositories/store.go
@@ -25,8 +25,9 @@ type MeterStoreRepository interface {
 
 type PlanStoreRepository interface {
 	CreatePlan(ctx context.Context, arg models.CreatePlanInput) (*models.Plan, error)
-	GetPlanByID(ctx context.Context, id string) (*models.Plan, error)
+	GetPlanByIDorSlug(ctx context.Context, idOrSlug string) (*models.Plan, error)
 	ListPlans(ctx context.Context, pagination pagination.Pagination) (*pagination.PaginationView[models.Plan], error)
-	DeletePlanByID(ctx context.Context, id string) error
-	UpdatePlanByID(ctx context.Context, id string, arg models.UpdatePlanInput) (*models.Plan, error)
+	DeletePlanByIDorSlug(ctx context.Context, idOrSlug string) error
+	UpdatePlanByIDorSlug(ctx context.Context, idOrSlug string, arg models.UpdatePlanInput) (*models.Plan, error)
+	ArchivePlanByIDorSlug(ctx context.Context, idOrSlug string, arg models.ArchivePlanInput) error
 }

--- a/application/services/plan.go
+++ b/application/services/plan.go
@@ -29,18 +29,18 @@ func (s *PlanService) CreatePlan(ctx context.Context, arg models.CreatePlanInput
 	return m, nil
 }
 
-func (s *PlanService) GetPlanByID(ctx context.Context, ID string) (*models.Plan, error) {
+func (s *PlanService) GetPlanByIDorSlug(ctx context.Context, IDorSlug string) (*models.Plan, error) {
 	// Call the repository to get the plan
-	m, err := s.store.GetPlanByID(ctx, ID)
+	m, err := s.store.GetPlanByIDorSlug(ctx, IDorSlug)
 	if err != nil {
 		return nil, err
 	}
 	return m, nil
 }
 
-func (s *PlanService) DeletePlan(ctx context.Context, ID string) error {
+func (s *PlanService) DeletePlan(ctx context.Context, IDorSlug string) error {
 
-	err := s.store.DeletePlanByID(ctx, ID)
+	err := s.store.DeletePlanByIDorSlug(ctx, IDorSlug)
 	if err != nil {
 		return err
 	}
@@ -48,9 +48,19 @@ func (s *PlanService) DeletePlan(ctx context.Context, ID string) error {
 	return nil
 }
 
-func (s *PlanService) UpdatePlan(ctx context.Context, ID string, arg models.UpdatePlanInput) (*models.Plan, error) {
+func (s *PlanService) ArchivePlan(ctx context.Context, IDorSlug string, arg models.ArchivePlanInput) error {
+
+	err := s.store.ArchivePlanByIDorSlug(ctx, IDorSlug, arg)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *PlanService) UpdatePlan(ctx context.Context, IDorSlug string, arg models.UpdatePlanInput) (*models.Plan, error) {
 	// Call the store repository to update the plan
-	m, err := s.store.UpdatePlanByID(ctx, ID, arg)
+	m, err := s.store.UpdatePlanByIDorSlug(ctx, IDorSlug, arg)
 	if err != nil {
 		return nil, err
 	}

--- a/bruno/plans/archive.bru
+++ b/bruno/plans/archive.bru
@@ -1,0 +1,22 @@
+meta {
+  name: archive
+  type: http
+  seq: 7
+}
+
+put {
+  url: {{base_url}}/v1/plans/6699fd55-f93e-42f1-8826-98cebd471257/archive
+  body: json
+  auth: inherit
+}
+
+headers {
+  x-tenant-slug: {{tenant_slug}}
+}
+
+body:json {
+  {
+    "updated_by":"test user",
+    "archive":true
+  }
+}

--- a/bruno/plans/create.bru
+++ b/bruno/plans/create.bru
@@ -17,6 +17,8 @@ headers {
 body:json {
   {
     "name": "RC_TENANT Free Plan",
+    "slug": "free_plan",
+    "type":"standard",
     "description": "Free Plan",
     "created_by": "rc_tenant_admin_user"
   }

--- a/bruno/plans/get_by_slug.bru
+++ b/bruno/plans/get_by_slug.bru
@@ -1,11 +1,11 @@
 meta {
-  name: delete
+  name: get_by_slug
   type: http
-  seq: 6
+  seq: 4
 }
 
-delete {
-  url: {{base_url}}/v1/plans/027fd502-f98b-48ca-a6d5-2c6a133954c2
+get {
+  url: {{base_url}}/v1/plans/free_plan
   body: none
   auth: inherit
 }

--- a/bruno/plans/update.bru
+++ b/bruno/plans/update.bru
@@ -1,7 +1,7 @@
 meta {
   name: update
   type: http
-  seq: 4
+  seq: 5
 }
 
 put {

--- a/domain/models/plan.go
+++ b/domain/models/plan.go
@@ -1,16 +1,43 @@
 package models
 
+import (
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// PlanTypeEnum represents the possible types of a plan
+type PlanTypeEnum string
+
+const (
+	Standard PlanTypeEnum = "standard"
+	Custom   PlanTypeEnum = "custom"
+)
+
+// ValidatePlanType returns true if the provided string is a valid plan type.
+func ValidatePlanType(value string) bool {
+	switch PlanTypeEnum(value) {
+	case Standard, Custom:
+		return true
+	default:
+		return false
+	}
+}
+
 // Plan represents a plan entity from the database
 type Plan struct {
 	Base
-	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
-	TenantSlug  string `json:"tenant_slug"`
+	Name        string             `json:"name"`
+	Description string             `json:"description,omitempty"`
+	Slug        string             `json:"slug"`
+	Type        PlanTypeEnum       `json:"type"`
+	ArchivedAt  pgtype.Timestamptz `json:"archived_at"`
+	TenantSlug  string             `json:"tenant_slug"`
 }
 
 // CreatePlanInput represents the input for creating a new plan
 type CreatePlanInput struct {
 	Name        string
+	PlanSlug    string
+	Type        PlanTypeEnum
 	Description string
 	CreatedBy   string
 }
@@ -19,4 +46,9 @@ type UpdatePlanInput struct {
 	Name        string
 	Description string
 	UpdatedBy   string
+}
+
+type ArchivePlanInput struct {
+	UpdatedBy string
+	Archive   bool
 }

--- a/infrastructure/postgres/gen/models.go
+++ b/infrastructure/postgres/gen/models.go
@@ -57,6 +57,48 @@ func (ns NullAggregationEnum) Value() (driver.Value, error) {
 	return string(ns.AggregationEnum), nil
 }
 
+type PlanTypeEnum string
+
+const (
+	PlanTypeEnumStandard PlanTypeEnum = "standard"
+	PlanTypeEnumCustom   PlanTypeEnum = "custom"
+)
+
+func (e *PlanTypeEnum) Scan(src interface{}) error {
+	switch s := src.(type) {
+	case []byte:
+		*e = PlanTypeEnum(s)
+	case string:
+		*e = PlanTypeEnum(s)
+	default:
+		return fmt.Errorf("unsupported scan type for PlanTypeEnum: %T", src)
+	}
+	return nil
+}
+
+type NullPlanTypeEnum struct {
+	PlanTypeEnum PlanTypeEnum
+	Valid        bool // Valid is true if PlanTypeEnum is not NULL
+}
+
+// Scan implements the Scanner interface.
+func (ns *NullPlanTypeEnum) Scan(value interface{}) error {
+	if value == nil {
+		ns.PlanTypeEnum, ns.Valid = "", false
+		return nil
+	}
+	ns.Valid = true
+	return ns.PlanTypeEnum.Scan(value)
+}
+
+// Value implements the driver Valuer interface.
+func (ns NullPlanTypeEnum) Value() (driver.Value, error) {
+	if !ns.Valid {
+		return nil, nil
+	}
+	return string(ns.PlanTypeEnum), nil
+}
+
 type Meter struct {
 	ID            pgtype.UUID
 	Name          string
@@ -76,10 +118,13 @@ type Meter struct {
 type Plan struct {
 	ID          pgtype.UUID
 	Name        string
+	Slug        string
 	Description pgtype.Text
+	Type        PlanTypeEnum
 	TenantSlug  string
 	CreatedAt   pgtype.Timestamptz
 	UpdatedAt   pgtype.Timestamptz
+	ArchivedAt  pgtype.Timestamptz
 	CreatedBy   string
 	UpdatedBy   string
 }

--- a/infrastructure/postgres/gen/querier.go
+++ b/infrastructure/postgres/gen/querier.go
@@ -11,6 +11,8 @@ import (
 )
 
 type Querier interface {
+	ArchivePlanByID(ctx context.Context, arg ArchivePlanByIDParams) (Plan, error)
+	ArchivePlanBySlug(ctx context.Context, arg ArchivePlanBySlugParams) (Plan, error)
 	CountMeters(ctx context.Context, tenantSlug string) (int64, error)
 	CountMetersByEventType(ctx context.Context, arg CountMetersByEventTypeParams) (int64, error)
 	CountPlans(ctx context.Context, tenantSlug string) (int64, error)
@@ -19,17 +21,22 @@ type Querier interface {
 	DeleteMeterByID(ctx context.Context, arg DeleteMeterByIDParams) error
 	DeleteMeterBySlug(ctx context.Context, arg DeleteMeterBySlugParams) error
 	DeletePlanByID(ctx context.Context, arg DeletePlanByIDParams) error
+	DeletePlanBySlug(ctx context.Context, arg DeletePlanBySlugParams) error
 	GetMeterByID(ctx context.Context, arg GetMeterByIDParams) (Meter, error)
 	GetMeterBySlug(ctx context.Context, arg GetMeterBySlugParams) (Meter, error)
 	GetPlanByID(ctx context.Context, arg GetPlanByIDParams) (Plan, error)
+	GetPlanBySlug(ctx context.Context, arg GetPlanBySlugParams) (Plan, error)
 	GetPropertiesByEventType(ctx context.Context, arg GetPropertiesByEventTypeParams) ([]interface{}, error)
 	GetValuePropertiesByEventType(ctx context.Context, arg GetValuePropertiesByEventTypeParams) ([]pgtype.Text, error)
 	ListMetersByEventTypes(ctx context.Context, arg ListMetersByEventTypesParams) ([]Meter, error)
 	ListMetersPaginated(ctx context.Context, arg ListMetersPaginatedParams) ([]Meter, error)
 	ListPlansPaginated(ctx context.Context, arg ListPlansPaginatedParams) ([]Plan, error)
+	UnArchivePlanByID(ctx context.Context, arg UnArchivePlanByIDParams) (Plan, error)
+	UnArchivePlanBySlug(ctx context.Context, arg UnArchivePlanBySlugParams) (Plan, error)
 	UpdateMeterByID(ctx context.Context, arg UpdateMeterByIDParams) (Meter, error)
 	UpdateMeterBySlug(ctx context.Context, arg UpdateMeterBySlugParams) (Meter, error)
 	UpdatePlanByID(ctx context.Context, arg UpdatePlanByIDParams) (Plan, error)
+	UpdatePlanBySlug(ctx context.Context, arg UpdatePlanBySlugParams) (Plan, error)
 }
 
 var _ Querier = (*Queries)(nil)

--- a/infrastructure/postgres/sql/schema.sql
+++ b/infrastructure/postgres/sql/schema.sql
@@ -25,13 +25,24 @@ create table "meter" (
   unique (tenant_slug, slug)
 );
 
+create type plan_type_enum as enum (
+	'standard',
+	'custom'
+);
+
 create table if not exists plan (
 	id uuid primary key default uuid_generate_v4(),
 	name varchar not null,
+	slug varchar not null,
 	description text,
+	type plan_type_enum not null,
 	tenant_slug varchar not null,
 	created_at timestamp with time zone not null default current_timestamp,
 	updated_at timestamp with time zone not null default current_timestamp,
+	archived_at timestamp with time zone default null,
 	created_by varchar not null,
-	updated_by varchar not null
+	updated_by varchar not null,
+
+	unique (tenant_slug, slug)
 );
+

--- a/infrastructure/postgres/store/plans/archive.go
+++ b/infrastructure/postgres/store/plans/archive.go
@@ -1,0 +1,60 @@
+package plans
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/redcardinal-io/metering/domain/models"
+	"github.com/redcardinal-io/metering/domain/pkg/constants"
+	"github.com/redcardinal-io/metering/infrastructure/postgres"
+	"github.com/redcardinal-io/metering/infrastructure/postgres/gen"
+	"go.uber.org/zap"
+)
+
+func (p *PgPlanStoreRepository) ArchivePlanByIDorSlug(ctx context.Context, idOrSlug string, arg models.ArchivePlanInput) error {
+	// Try to parse as UUID first
+	tenantSlug := ctx.Value(constants.TenantSlugKey).(string)
+	parsedId, err := uuid.Parse(idOrSlug)
+	var archiveErr error
+	if err == nil {
+		// Valid UUID, get details by ID
+		if arg.Archive {
+			_, archiveErr = p.q.ArchivePlanByID(ctx, gen.ArchivePlanByIDParams{
+				ID:         pgtype.UUID{Bytes: parsedId, Valid: true},
+				UpdatedBy:  arg.UpdatedBy,
+				TenantSlug: tenantSlug,
+			})
+		} else {
+			_, archiveErr = p.q.UnArchivePlanByID(ctx, gen.UnArchivePlanByIDParams{
+				ID:         pgtype.UUID{Bytes: parsedId, Valid: true},
+				UpdatedBy:  arg.UpdatedBy,
+				TenantSlug: tenantSlug,
+			})
+		}
+
+	} else {
+		// Not a UUID, get details by slug
+		if arg.Archive {
+			_, archiveErr = p.q.ArchivePlanBySlug(ctx, gen.ArchivePlanBySlugParams{
+				Slug:       idOrSlug,
+				TenantSlug: tenantSlug,
+				UpdatedBy:  arg.UpdatedBy,
+			})
+		} else {
+			_, archiveErr = p.q.UnArchivePlanBySlug(ctx, gen.UnArchivePlanBySlugParams{
+				Slug:       idOrSlug,
+				TenantSlug: tenantSlug,
+				UpdatedBy:  arg.UpdatedBy,
+			})
+		}
+	}
+
+	// Handle errors from either delete operation
+	if archiveErr != nil {
+		p.logger.Error("failed to archive plan", zap.Error(archiveErr))
+		return postgres.MapError(archiveErr, "Postgres.ArchivePlan")
+	}
+
+	return nil
+}

--- a/infrastructure/postgres/store/plans/create.go
+++ b/infrastructure/postgres/store/plans/create.go
@@ -16,6 +16,8 @@ func (p *PgPlanStoreRepository) CreatePlan(ctx context.Context, arg models.Creat
 	tenantSlug := ctx.Value(constants.TenantSlugKey).(string)
 	m, err := p.q.CreatePlan(ctx, gen.CreatePlanParams{
 		Name:        arg.Name,
+		Slug:        arg.PlanSlug,
+		Type:        gen.PlanTypeEnum(arg.Type),
 		Description: pgtype.Text{String: arg.Description, Valid: arg.Description != ""},
 		TenantSlug:  tenantSlug,
 		CreatedBy:   arg.CreatedBy,
@@ -35,7 +37,10 @@ func (p *PgPlanStoreRepository) CreatePlan(ctx context.Context, arg models.Creat
 
 	plan := &models.Plan{
 		Name:        m.Name,
+		Slug:        m.Slug,
+		Type:        models.PlanTypeEnum(m.Type),
 		Description: m.Description.String,
+		ArchivedAt:  m.ArchivedAt,
 		TenantSlug:  m.TenantSlug,
 		Base: models.Base{
 			ID:        id,

--- a/infrastructure/postgres/store/plans/list.go
+++ b/infrastructure/postgres/store/plans/list.go
@@ -34,6 +34,9 @@ func (p *PgPlanStoreRepository) ListPlans(ctx context.Context, page pagination.P
 		}
 		plans = append(plans, models.Plan{
 			Name:        plan.Name,
+			Slug:        plan.Slug,
+			Type:        models.PlanTypeEnum(plan.Type),
+			ArchivedAt:  plan.ArchivedAt,
 			Description: plan.Description.String,
 			TenantSlug:  plan.TenantSlug,
 			Base: models.Base{

--- a/interfaces/http/routes/v1/plans/archive.go
+++ b/interfaces/http/routes/v1/plans/archive.go
@@ -10,23 +10,22 @@ import (
 	"go.uber.org/zap"
 )
 
-type updatePlanRequest struct {
-	Name        string `json:"name,omitempty" validate:"omitempty,min=3,max=100"`
-	Description string `json:"description,omitempty" validate:"omitempty,min=3,max=255"`
-	UpdatedBy   string `json:"updated_by" validate:"required,min=3,max=255"`
+type archivePlanRequest struct {
+	UpdatedBy string `json:"updated_by" validate:"required,min=3,max=255"`
+	Archive   bool   `json:"archive"`
 }
 
-func (h *httpHandler) updateByIDorSlug(ctx *fiber.Ctx) error {
+func (h *httpHandler) archive(ctx *fiber.Ctx) error {
 	tenantSlug := ctx.Get(constants.TenantHeader)
 	idOrSlug := ctx.Params("idOrSlug")
 
 	if idOrSlug == "" {
-		errResp := domainerrors.NewErrorResponseWithOpts(nil, domainerrors.EINVALID, "plan ID is required")
-		h.logger.Error("plan ID is required", zap.Reflect("error", errResp))
+		errResp := domainerrors.NewErrorResponseWithOpts(nil, domainerrors.EINVALID, "Plan Id or Slug is required")
+		h.logger.Error("Plan Id or Slug is required", zap.Reflect("error", errResp))
 		return ctx.Status(errResp.Status).JSON(errResp.ToJson())
 	}
 
-	var req updatePlanRequest
+	var req archivePlanRequest
 	if err := ctx.BodyParser(&req); err != nil {
 		errResp := domainerrors.NewErrorResponseWithOpts(err, domainerrors.EINVALID, "failed to parse request body")
 		h.logger.Error("failed to parse request body", zap.Reflect("error", errResp))
@@ -39,25 +38,19 @@ func (h *httpHandler) updateByIDorSlug(ctx *fiber.Ctx) error {
 		h.logger.Error("invalid request body", zap.Reflect("error", errResp))
 		return ctx.Status(errResp.Status).JSON(errResp.ToJson())
 	}
-	if req.Name == "" && req.Description == "" {
-		errResp := domainerrors.NewErrorResponseWithOpts(nil, domainerrors.EINVALID, "at least one field (name or description) is required")
-		h.logger.Error("at least one field (name or description) is required", zap.Reflect("error", errResp))
-		return ctx.Status(errResp.Status).JSON(errResp.ToJson())
-	}
 
 	c := context.WithValue(ctx.UserContext(), constants.TenantSlugKey, tenantSlug)
 
-	plan, err := h.planSvc.UpdatePlan(c, idOrSlug, models.UpdatePlanInput{
-		Name:        req.Name,
-		Description: req.Description,
-		UpdatedBy:   req.UpdatedBy,
+	err := h.planSvc.ArchivePlan(c, idOrSlug, models.ArchivePlanInput{
+		UpdatedBy: req.UpdatedBy,
+		Archive:   req.Archive,
 	})
 	if err != nil {
-		h.logger.Error("failed to update plan", zap.String("id", idOrSlug), zap.Reflect("error", err))
+		h.logger.Error("failed to toggle archive plan", zap.String("id", idOrSlug), zap.Reflect("error", err))
 		errResp := domainerrors.NewErrorResponse(err)
 		return ctx.Status(errResp.Status).JSON(errResp.ToJson())
 	}
 
 	return ctx.
-		Status(fiber.StatusOK).JSON(models.NewHttpResponse(plan, "plan updated successfully", fiber.StatusOK))
+		SendStatus(fiber.StatusNoContent)
 }

--- a/interfaces/http/routes/v1/plans/create.go
+++ b/interfaces/http/routes/v1/plans/create.go
@@ -12,6 +12,8 @@ import (
 
 type createPlanRequest struct {
 	Name        string `json:"name" validate:"required"`
+	Slug        string `json:"slug" validate:"required"`
+	Type        string `json:"type" validate:"required,oneof=standard custom"`
 	Description string `json:"description,omitempty"`
 	CreatedBy   string `json:"created_by" validate:"required"`
 }
@@ -36,6 +38,8 @@ func (h *httpHandler) create(ctx *fiber.Ctx) error {
 
 	plan, err := h.planSvc.CreatePlan(c, models.CreatePlanInput{
 		Name:        req.Name,
+		PlanSlug:    req.Slug,
+		Type:        models.PlanTypeEnum(req.Type),
 		Description: req.Description,
 		CreatedBy:   req.CreatedBy,
 	})

--- a/interfaces/http/routes/v1/plans/delete.go
+++ b/interfaces/http/routes/v1/plans/delete.go
@@ -14,8 +14,8 @@ func (h *httpHandler) deleteByIDorSlug(ctx *fiber.Ctx) error {
 	idOrSlug := ctx.Params("idOrSlug")
 
 	if idOrSlug == "" {
-		errResp := domainerrors.NewErrorResponseWithOpts(nil, domainerrors.EINVALID, "plan ID is required")
-		h.logger.Error("plan ID is required", zap.Reflect("error", errResp))
+		errResp := domainerrors.NewErrorResponseWithOpts(nil, domainerrors.EINVALID, "plan ID or Slug is required")
+		h.logger.Error("plan ID or Slug is required", zap.Reflect("error", errResp))
 		return ctx.Status(errResp.Status).JSON(errResp.ToJson())
 	}
 

--- a/interfaces/http/routes/v1/plans/delete.go
+++ b/interfaces/http/routes/v1/plans/delete.go
@@ -9,11 +9,11 @@ import (
 	"go.uber.org/zap"
 )
 
-func (h *httpHandler) deleteByID(ctx *fiber.Ctx) error {
+func (h *httpHandler) deleteByIDorSlug(ctx *fiber.Ctx) error {
 	tenantSlug := ctx.Get(constants.TenantHeader)
-	id := ctx.Params("id")
+	idOrSlug := ctx.Params("idOrSlug")
 
-	if id == "" {
+	if idOrSlug == "" {
 		errResp := domainerrors.NewErrorResponseWithOpts(nil, domainerrors.EINVALID, "plan ID is required")
 		h.logger.Error("plan ID is required", zap.Reflect("error", errResp))
 		return ctx.Status(errResp.Status).JSON(errResp.ToJson())
@@ -21,9 +21,9 @@ func (h *httpHandler) deleteByID(ctx *fiber.Ctx) error {
 
 	c := context.WithValue(ctx.UserContext(), constants.TenantSlugKey, tenantSlug)
 
-	err := h.planSvc.DeletePlan(c, id)
+	err := h.planSvc.DeletePlan(c, idOrSlug)
 	if err != nil {
-		h.logger.Error("failed to delete plan", zap.String("id", id), zap.Reflect("error", err))
+		h.logger.Error("failed to delete plan", zap.String("id", idOrSlug), zap.Reflect("error", err))
 		errResp := domainerrors.NewErrorResponse(err)
 		return ctx.Status(errResp.Status).JSON(errResp.ToJson())
 	}

--- a/interfaces/http/routes/v1/plans/details.go
+++ b/interfaces/http/routes/v1/plans/details.go
@@ -10,11 +10,11 @@ import (
 	"go.uber.org/zap"
 )
 
-func (h *httpHandler) getByID(ctx *fiber.Ctx) error {
+func (h *httpHandler) getByIDorSlug(ctx *fiber.Ctx) error {
 	tenantSlug := ctx.Get(constants.TenantHeader)
-	id := ctx.Params("id")
+	idOrSlug := ctx.Params("idOrSlug")
 
-	if id == "" {
+	if idOrSlug == "" {
 		errResp := domainerrors.NewErrorResponseWithOpts(nil, domainerrors.EINVALID, "plan ID is required")
 		h.logger.Error("plan ID is required", zap.Reflect("error", errResp))
 		return ctx.Status(errResp.Status).JSON(errResp.ToJson())
@@ -22,9 +22,9 @@ func (h *httpHandler) getByID(ctx *fiber.Ctx) error {
 
 	c := context.WithValue(ctx.UserContext(), constants.TenantSlugKey, tenantSlug)
 
-	plan, err := h.planSvc.GetPlanByID(c, id)
+	plan, err := h.planSvc.GetPlanByIDorSlug(c, idOrSlug)
 	if err != nil {
-		h.logger.Error("failed to get plan", zap.String("id", id), zap.Reflect("error", err))
+		h.logger.Error("failed to get plan", zap.String("id", idOrSlug), zap.Reflect("error", err))
 		errResp := domainerrors.NewErrorResponse(err)
 		return ctx.Status(errResp.Status).JSON(errResp.ToJson())
 	}

--- a/interfaces/http/routes/v1/plans/routes.go
+++ b/interfaces/http/routes/v1/plans/routes.go
@@ -32,7 +32,11 @@ func (h *httpHandler) RegisterRoutes(r fiber.Router) {
 	plans.Get("/", h.list)
 
 	// Single Plan routes with id parameter
-	plans.Get("/:id", h.getByID)
-	plans.Put("/:id", h.updateByID)
-	plans.Delete("/:id", h.deleteByID)
+	plans.Get("/:idOrSlug", h.getByIDorSlug)
+	plans.Put("/:idOrSlug", h.updateByIDorSlug)
+	plans.Delete("/:idOrSlug", h.deleteByIDorSlug)
+
+	// Toggle Plan Archive
+	plans.Put("/:idOrSlug/archive", h.archive)
+
 }

--- a/migrations/postgres/20250513202626_plan.go
+++ b/migrations/postgres/20250513202626_plan.go
@@ -15,16 +15,29 @@ func upPlan(ctx context.Context, tx *sql.Tx) error {
 	_, err := tx.ExecContext(ctx, `
 		do $$
 		begin
+      -- check if type exists and create it if it doesn't
+			if not exists (select 1 from pg_type where typname = 'plan_type_enum') then
+				create type plan_type_enum as enum (
+					'standard',
+					'custom'
+				);
+			end if;
+
 			-- create table and indexes
 			create table if not exists plan (
 				id uuid primary key default uuid_generate_v4(),
 				name varchar not null,
+				slug varchar not null,
 				description text,
+        type plan_type_enum not null,
 				tenant_slug varchar not null,
         created_at timestamp with time zone not null default current_timestamp,
         updated_at timestamp with time zone not null default current_timestamp,
+        archived_at timestamp with time zone default null,
         created_by varchar not null,
-        updated_by varchar not null
+        updated_by varchar not null,
+
+        unique (tenant_slug, slug)
 			);
 		  
       perform goose_manage_updated_at('plan');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Plans can now be managed (retrieved, updated, or deleted) using either a unique ID or a slug.
  - Added support for archiving and unarchiving plans via a new API endpoint.
  - Plans now include a slug, type (standard or custom), and an archived status.
  - Unique slugs are enforced per tenant for plans.

- **API Changes**
  - Plan creation requires a slug and type.
  - New endpoints and updated routes allow operations by ID or slug.
  - New endpoint for archiving/unarchiving plans.

- **Database Changes**
  - Plans table now includes slug, type, and archived_at fields.
  - Added unique constraint on tenant and slug combination.
  - New enum type for plan classification (standard/custom).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->