### PR TITLE
chore: move time range validation to service layer

### DIFF
--- a/application/services/plan_management.go
+++ b/application/services/plan_management.go
@@ -77,17 +77,29 @@ func (s *PlanManagementService) validateAssignmentTimeRange(
 	existingValidFrom := existingAssignment.ValidFrom
 	existingValidUntil := existingAssignment.ValidUntil
 
-	if !updateInput.ValidFrom.IsZero() && updateInput.ValidFrom.Before(existingValidFrom) {
-		return domainerrors.New(errors.New("valid_from cannot be before the current valid_from"), domainerrors.EINVALID, "valid_from cannot be before the current valid_from")
-	}
+    if !updateInput.ValidFrom.IsZero() && updateInput.ValidFrom.Before(existingValidFrom) {
+        return domainerrors.New(
+            fmt.Errorf("valid_from cannot be before the current valid_from: %s", existingValidFrom),
+            domainerrors.EINVALID,
+            fmt.Sprintf("valid_from cannot be before the current valid_from: %s", existingValidFrom),
+        )
+    }
 
-	if !updateInput.ValidFrom.IsZero() && updateInput.ValidFrom.After(existingValidUntil) {
-		return domainerrors.New(errors.New(fmt.Sprintf("valid_from cannot be after the current valid_until: %s", existingValidUntil)), domainerrors.EINVALID, fmt.Sprintf("valid_from cannot be after the current valid_until: %s", existingValidUntil))
-	}
+    if !updateInput.ValidFrom.IsZero() && updateInput.ValidFrom.After(existingValidUntil) {
+        return domainerrors.New(
+            fmt.Errorf("valid_from cannot be after the current valid_until: %s", existingValidUntil),
+            domainerrors.EINVALID,
+            fmt.Sprintf("valid_from cannot be after the current valid_until: %s", existingValidUntil),
+        )
+    }
 
-	if !updateInput.ValidUntil.IsZero() && !existingValidUntil.IsZero() && updateInput.ValidUntil.After(existingValidUntil) {
-		return domainerrors.New(errors.New("valid_until cannot be after the current valid_until"), domainerrors.EINVALID, "valid_until cannot be after the current valid_until")
-	}
+    if !updateInput.ValidUntil.IsZero() && !existingValidUntil.IsZero() && updateInput.ValidUntil.After(existingValidUntil) {
+        return domainerrors.New(
+            fmt.Errorf("valid_until cannot be after the current valid_until: %s", existingValidUntil),
+            domainerrors.EINVALID,
+            fmt.Sprintf("valid_until cannot be after the current valid_until: %s", existingValidUntil),
+        )
+    }
 	return nil
 }
 

--- a/application/services/plan_management_test.go
+++ b/application/services/plan_management_test.go
@@ -1,0 +1,241 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/redcardinal-io/metering/domain/models"
+	"github.com/redcardinal-io/metering/domain/pkg/pagination"
+)
+
+// MockPlanAssignmentsStoreRepository is a mock implementation of the PlanAssignmentsStoreRepository interface
+type MockPlanAssignmentsStoreRepository struct {
+	mock.Mock
+}
+
+// Implement the interface methods for the mock
+func (m *MockPlanAssignmentsStoreRepository) CreateAssignment(ctx context.Context, arg models.CreateAssignmentInput) (*models.PlanAssignment, error) {
+	args := m.Called(ctx, arg)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.PlanAssignment), args.Error(1)
+}
+
+func (m *MockPlanAssignmentsStoreRepository) TerminateAssignment(ctx context.Context, arg models.TerminateAssignmentInput) error {
+	args := m.Called(ctx, arg)
+	return args.Error(0)
+}
+
+func (m *MockPlanAssignmentsStoreRepository) UpdateAssignment(ctx context.Context, arg models.UpdateAssignmentInput) (*models.PlanAssignment, error) {
+	args := m.Called(ctx, arg)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.PlanAssignment), args.Error(1)
+}
+
+func (m *MockPlanAssignmentsStoreRepository) ListAssignments(ctx context.Context, arg models.QueryPlanAssignmentInput, p pagination.Pagination) (*pagination.PaginationView[models.PlanAssignment], error) {
+	args := m.Called(ctx, arg, p)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*pagination.PaginationView[models.PlanAssignment]), args.Error(1)
+}
+
+func (m *MockPlanAssignmentsStoreRepository) ListAssignmentsHistory(ctx context.Context, arg models.QueryPlanAssignmentHistoryInput, p pagination.Pagination) (*pagination.PaginationView[models.PlanAssignmentHistory], error) {
+	args := m.Called(ctx, arg, p)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*pagination.PaginationView[models.PlanAssignmentHistory]), args.Error(1)
+}
+
+func (m *MockPlanAssignmentsStoreRepository) ListAllAssignments(ctx context.Context, p pagination.Pagination) (*pagination.PaginationView[models.PlanAssignment], error) {
+	args := m.Called(ctx, p)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*pagination.PaginationView[models.PlanAssignment]), args.Error(1)
+}
+
+func TestValidateAssignmentTimeRange(t *testing.T) {
+	// Define common variables for tests
+	ctx := context.Background()
+	now := time.Now().UTC()
+	planID := uuid.New()
+	orgID := uuid.New()
+	userID := uuid.New()
+
+	// Define test cases
+	tests := []struct {
+		name         string
+		setupMock    func(*MockPlanAssignmentsStoreRepository)
+		updateInput  models.UpdateAssignmentInput
+		expectedErr  bool
+		exactMessage string
+	}{
+		{
+			name: "error with no existing assignments",
+			setupMock: func(m *MockPlanAssignmentsStoreRepository) {
+				m.On("ListAssignments", mock.Anything, mock.Anything, mock.Anything).
+					Return(&pagination.PaginationView[models.PlanAssignment]{
+						Results: []models.PlanAssignment{},
+						Total:   0,
+					}, nil)
+			},
+			updateInput: models.UpdateAssignmentInput{
+				PlanID:         &planID,
+				OrganizationID: orgID.String(),
+				UserID:         userID.String(),
+				ValidFrom:      now.Add(24 * time.Hour),
+				ValidUntil:     now.Add(48 * time.Hour),
+			},
+			expectedErr:  true,
+			exactMessage: "no existing assignment found",
+		},
+		{
+			name: "error when listing assignments",
+			setupMock: func(m *MockPlanAssignmentsStoreRepository) {
+				m.On("ListAssignments", mock.Anything, mock.Anything, mock.Anything).
+					Return(nil, errors.New("database error"))
+			},
+			updateInput: models.UpdateAssignmentInput{
+				PlanID:         &planID,
+				OrganizationID: orgID.String(),
+				UserID:         userID.String(),
+			},
+			expectedErr:  true,
+			exactMessage: "failed to list assignments",
+		},
+		{
+			name: "error when valid from is before existing assignment's valid from",
+			setupMock: func(m *MockPlanAssignmentsStoreRepository) {
+				m.On("ListAssignments", mock.Anything, mock.Anything, mock.Anything).
+					Return(&pagination.PaginationView[models.PlanAssignment]{
+						Results: []models.PlanAssignment{{
+							ValidFrom:  now,
+							ValidUntil: now.Add(24 * time.Hour),
+						}},
+						Total: 1,
+					}, nil)
+			},
+			updateInput: models.UpdateAssignmentInput{
+				PlanID:         &planID,
+				OrganizationID: orgID.String(),
+				UserID:         userID.String(),
+				ValidFrom:      now.Add(-1 * time.Hour),
+				ValidUntil:     now.Add(1 * time.Hour),
+			},
+			expectedErr:  true,
+			exactMessage: "valid_from cannot be before the current valid_from",
+		},
+		{
+			name: "error when valid until is after existing assignment's valid until",
+			setupMock: func(m *MockPlanAssignmentsStoreRepository) {
+				m.On("ListAssignments", mock.Anything, mock.Anything, mock.Anything).
+					Return(&pagination.PaginationView[models.PlanAssignment]{
+						Results: []models.PlanAssignment{{
+							ValidFrom:  now,
+							ValidUntil: now.Add(24 * time.Hour),
+						}},
+						Total: 1,
+					}, nil)
+			},
+			updateInput: models.UpdateAssignmentInput{
+				PlanID:         &planID,
+				OrganizationID: orgID.String(),
+				UserID:         userID.String(),
+				ValidFrom:      now.Add(1 * time.Hour),
+				ValidUntil:     now.Add(48 * time.Hour),
+			},
+			expectedErr:  true,
+			exactMessage: "valid_until cannot be after the current valid_until",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Initialize mock
+			mockRepo := new(MockPlanAssignmentsStoreRepository)
+			tt.setupMock(mockRepo)
+
+			// Initialize service with mock
+			service := &PlanManagementService{
+				planAssignmentsStore: mockRepo,
+			}
+
+			// Execute the method under test
+			err := service.validateAssignmentTimeRange(ctx, tt.updateInput)
+
+			// Assertions
+			if tt.expectedErr {
+				assert.Error(t, err)
+				if tt.exactMessage != "" {
+					assert.Contains(t, err.Error(), tt.exactMessage)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+
+			// Verify mock expectations
+			mockRepo.AssertExpectations(t)
+		})
+	}
+}
+
+// Test with successful validation when assignment exists
+func TestValidateAssignmentTimeRangeSuccessful(t *testing.T) {
+	// Setup test data
+	ctx := context.Background()
+	now := time.Now().UTC()
+	planID := uuid.New()
+	orgID := uuid.New()
+	userID := uuid.New()
+
+	// Create mock repository
+	mockRepo := new(MockPlanAssignmentsStoreRepository)
+
+	// Create service with mocked dependencies
+	service := PlanManagementService{
+		planAssignmentsStore: mockRepo,
+	}
+
+	// Set up the test case where ListAssignments returns a valid assignment
+	updateInput := models.UpdateAssignmentInput{
+		PlanID:         &planID,
+		OrganizationID: orgID.String(),
+		UserID:         userID.String(),
+		ValidFrom:      now.Add(1 * time.Hour),
+		ValidUntil:     now.Add(23 * time.Hour),
+	}
+
+	// Mock the ListAssignments to return a valid assignment
+	mockRepo.On("ListAssignments", mock.Anything, mock.Anything, mock.Anything).Return(
+		&pagination.PaginationView[models.PlanAssignment]{
+			Results: []models.PlanAssignment{
+				{
+					ValidFrom:  now,
+					ValidUntil: now.Add(24 * time.Hour),
+				},
+			},
+			Total: 1,
+		},
+		nil,
+	)
+
+	// Test the function
+	err := service.validateAssignmentTimeRange(ctx, updateInput)
+
+	// Verify no error is returned for a valid time range
+	assert.NoError(t, err, "Expected no error for valid time range")
+
+	// Verify the mock was called as expected
+	mockRepo.AssertExpectations(t)
+}

--- a/domain/errors/errors.go
+++ b/domain/errors/errors.go
@@ -119,7 +119,11 @@ func New(err error, code ErrorCode, message string, opts ...ErrorOption) *AppErr
 	}
 
 	// If message is empty, use error string
-	message = fmt.Sprintf("%s: %s", message, err.Error())
+	if message == "" {
+		message = err.Error()
+	} else {
+		message = fmt.Sprintf("%s: %s", message, err.Error())
+	}
 
 	data := make(map[string]any)
 	if appErr != nil && appErr.Data != nil {

--- a/domain/errors/errors.go
+++ b/domain/errors/errors.go
@@ -119,9 +119,7 @@ func New(err error, code ErrorCode, message string, opts ...ErrorOption) *AppErr
 	}
 
 	// If message is empty, use error string
-	if message == "" {
-		message = err.Error()
-	}
+	message = fmt.Sprintf("%s: %s", message, err.Error())
 
 	data := make(map[string]any)
 	if appErr != nil && appErr.Data != nil {

--- a/infrastructure/postgres/gen/plan.sql.go
+++ b/infrastructure/postgres/gen/plan.sql.go
@@ -244,6 +244,7 @@ const listPlansPaginated = `-- name: ListPlansPaginated :many
 SELECT id, name, slug, description, type, tenant_slug, created_at, updated_at, archived_at, created_by, updated_by FROM plan
 WHERE tenant_slug = $1
 and ($4::plan_type_enum is null or type = $4::plan_type_enum)
+and ($5::boolean is null or archived_at is not null = $5::boolean)
 ORDER BY created_at DESC
 LIMIT $2
 OFFSET $3
@@ -254,6 +255,7 @@ type ListPlansPaginatedParams struct {
 	Limit      int32
 	Offset     int32
 	Type       NullPlanTypeEnum
+	Archived   pgtype.Bool
 }
 
 func (q *Queries) ListPlansPaginated(ctx context.Context, arg ListPlansPaginatedParams) ([]Plan, error) {
@@ -262,6 +264,7 @@ func (q *Queries) ListPlansPaginated(ctx context.Context, arg ListPlansPaginated
 		arg.Limit,
 		arg.Offset,
 		arg.Type,
+		arg.Archived,
 	)
 	if err != nil {
 		return nil, err

--- a/infrastructure/postgres/sql/queries/plan.sql
+++ b/infrastructure/postgres/sql/queries/plan.sql
@@ -25,6 +25,7 @@ AND tenant_slug = $2;
 SELECT * FROM plan
 WHERE tenant_slug = $1
 and (sqlc.narg('type')::plan_type_enum is null or type = sqlc.narg('type')::plan_type_enum)
+and (sqlc.narg('archived')::boolean is null or archived_at is not null = sqlc.narg('archived')::boolean)
 ORDER BY created_at DESC
 LIMIT $2
 OFFSET $3;

--- a/infrastructure/postgres/sql/queries/plan_feature.sql
+++ b/infrastructure/postgres/sql/queries/plan_feature.sql
@@ -35,14 +35,16 @@ select
     f.slug as feature_slug,
     f.description as feature_description,
     f.type as feature_type,
-    f.config as feature_config,
-    f.tenant_slug as feature_tenant_slug
+    f.config as feature_config
 from 
     plan_feature pf
 join
     feature f on pf.feature_id = f.id
+join
+    plan p on pf.plan_id = p.id
 where
     pf.plan_id = $1
+    and p.tenant_slug = $2
     and (sqlc.narg('feature_type')::feature_enum is null or f.type = sqlc.narg('feature_type')::feature_enum)
 order by
     pf.created_at desc;

--- a/infrastructure/postgres/store/planfeatures/create.go
+++ b/infrastructure/postgres/store/planfeatures/create.go
@@ -57,7 +57,7 @@ func (p *PgPlanFeatureStoreRepository) CreatePlanFeature(ctx context.Context, ar
 	planFeature := &models.PlanFeature{
 		PlanID:    planID,
 		FeatureID: featureID,
-		Config:    m.Config,
+		Config:    UnMarshalPlanFeatureConfig(m.Config),
 		Base: models.Base{
 			ID:        id,
 			CreatedAt: m.CreatedAt.Time,

--- a/infrastructure/postgres/store/planfeatures/list.go
+++ b/infrastructure/postgres/store/planfeatures/list.go
@@ -14,6 +14,8 @@ import (
 func (p *PgPlanFeatureStoreRepository) ListPlanFeaturesByPlan(ctx context.Context, planID uuid.UUID, filter models.PlanFeatureListFilter) ([]models.PlanFeature, error) {
 	params := gen.ListPlanFeaturesByPlanParams{
 		PlanID: pgtype.UUID{Bytes: planID, Valid: true},
+		// INFO: TenantSlug is set from context, so we can use it directly
+		TenantSlug: ctx.Value("tenant_slug").(string),
 	}
 	if filter.FeatureType != "" {
 		params.FeatureType = gen.NullFeatureEnum{
@@ -51,7 +53,7 @@ func (p *PgPlanFeatureStoreRepository) ListPlanFeaturesByPlan(ctx context.Contex
 		planFeatures = append(planFeatures, models.PlanFeature{
 			PlanID:      planIDResult,
 			FeatureID:   featureIDResult,
-			Config:      row.Config,
+			Config:      UnMarshalPlanFeatureConfig(row.Config),
 			FeatureName: row.FeatureName,
 			FeatureSlug: row.FeatureSlug,
 			Type:        models.FeatureTypeEnum(row.FeatureType),

--- a/infrastructure/postgres/store/planfeatures/plan_features.go
+++ b/infrastructure/postgres/store/planfeatures/plan_features.go
@@ -1,6 +1,8 @@
 package planfeatures
 
 import (
+	"encoding/json"
+
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redcardinal-io/metering/application/repositories"
 	"github.com/redcardinal-io/metering/domain/pkg/logger"
@@ -17,4 +19,15 @@ func NewPgPlanFeatureStoreRepository(db any, logger *logger.Logger) repositories
 		q:      gen.New(db.(*pgxpool.Pool)),
 		logger: logger,
 	}
+}
+
+func UnMarshalPlanFeatureConfig(configBytes []byte) map[string]any {
+	if configBytes == nil {
+		return nil
+	}
+
+	var config map[string]any
+	// INFO: As configBytes is returned from database, it is expected to be in JSON format. So we can unmarshal it directly.
+	_ = json.Unmarshal(configBytes, &config)
+	return config
 }

--- a/infrastructure/postgres/store/planfeatures/update.go
+++ b/infrastructure/postgres/store/planfeatures/update.go
@@ -56,7 +56,7 @@ func (p *PgPlanFeatureStoreRepository) UpdatePlanFeature(ctx context.Context, pl
 	planFeature := &models.PlanFeature{
 		PlanID:    planIDResult,
 		FeatureID: featureIDResult,
-		Config:    m.Config,
+		Config:    UnMarshalPlanFeatureConfig(m.Config),
 		Base: models.Base{
 			ID:        id,
 			CreatedAt: m.CreatedAt.Time,

--- a/infrastructure/postgres/store/plans/list.go
+++ b/infrastructure/postgres/store/plans/list.go
@@ -3,6 +3,7 @@ package plans
 import (
 	"context"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/redcardinal-io/metering/domain/models"
 	"github.com/redcardinal-io/metering/domain/pkg/constants"
 	"github.com/redcardinal-io/metering/domain/pkg/pagination"
@@ -18,6 +19,10 @@ func (p *PgPlanStoreRepository) ListPlans(ctx context.Context, page pagination.P
 		Offset:     int32(page.GetOffset()),
 		TenantSlug: ctx.Value(constants.TenantSlugKey).(string),
 		Type:       createPlanTypeEnum(page.Queries["type"]),
+		Archived: pgtype.Bool{
+			Valid: page.Queries["archived"] != "",
+			Bool:  page.Queries["archived"] == "true",
+		},
 	})
 	if err != nil {
 		p.logger.Error("Error listing plans: ", zap.Error(err))

--- a/infrastructure/postgres/store/quotas/create.go
+++ b/infrastructure/postgres/store/quotas/create.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
+	domainerrors "github.com/redcardinal-io/metering/domain/errors"
 	"github.com/redcardinal-io/metering/domain/models"
 	"github.com/redcardinal-io/metering/infrastructure/postgres"
 	"github.com/redcardinal-io/metering/infrastructure/postgres/gen"
@@ -21,7 +22,7 @@ func (r *PlanFeatureQuotaRepository) CreatePlanFeatureQuota(ctx context.Context,
 	}
 	if !isMetered {
 		r.logger.Error("quota can only be set for metered features", zap.String("planFeatureID", arg.PlanFeatureID))
-		return nil, errors.New("quota can only be set for metered features")
+		return nil, domainerrors.New(errors.New("quota can only be set for metered features"), domainerrors.EINVALID, "quota can only be set for metered features")
 	}
 
 	planFeatureID := uuid.MustParse(arg.PlanFeatureID)

--- a/interfaces/http/routes/v1/assignments/list.go
+++ b/interfaces/http/routes/v1/assignments/list.go
@@ -2,6 +2,7 @@ package assignments
 
 import (
 	"context"
+	"regexp"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -13,17 +14,37 @@ import (
 	"go.uber.org/zap"
 )
 
+// validateUUID checks if a string is a valid UUID
+func validateUUID(id string) bool {
+	if id == "" {
+		return true // Empty is allowed for optional params
+	}
+
+	regex := regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+	return regex.MatchString(id)
+}
+
+// validateTimeFormat checks if a string is in the correct time format
+func validateTimeFormat(t string) bool {
+	if t == "" {
+		return true // Empty is allowed for optional params
+	}
+
+	_, err := time.Parse(constants.TimeFormat, t)
+	return err == nil
+}
+
 // @Summary List plan assignments
 // @Description Get a list of plan assignments with optional filtering
 // @Tags plan-assignments
 // @Accept json
 // @Produce json
 // @Param X-Tenant-Slug header string true "Tenant Slug"
-// @Param validFrom query string false "Valid from date (format: YYYY-MM-DDThh:mm:ssZ)"
-// @Param validUntil query string false "Valid until date (format: YYYY-MM-DDThh:mm:ssZ)"
-// @Param planIdOrSlug query string false "Plan ID or slug"
-// @Param orgId query string false "Organization ID"
-// @Param userId query string false "User ID"
+// @Param valid_from query string false "Valid from date (format: YYYY-MM-DDThh:mm:ssZ)"
+// @Param valid_until query string false "Valid until date (format: YYYY-MM-DDThh:mm:ssZ)"
+// @Param plan_id_or_slug query string false "Plan ID or slug"
+// @Param org_id query string false "Organization ID"
+// @Param user_id query string false "User ID"
 // @Param page query int false "Page number"
 // @Param limit query int false "Items per page"
 // @Success 200 {object} models.HttpResponse[pagination.PaginationView[models.PlanAssignment]] "Assignments retrieved successfully"
@@ -36,13 +57,48 @@ func (h *httpHandler) list(ctx *fiber.Ctx) error {
 	var genErr error
 	var planId *uuid.UUID
 	var planassignments *pagination.PaginationView[models.PlanAssignment]
-	validFrom := ctx.Query("validFrom")
-	validUntil := ctx.Query("validUntil")
-	planIdOrSlug := ctx.Query("planIdOrSlug")
+	validFrom := ctx.Query("valid_from")
+	validUntil := ctx.Query("valid_until")
+	planIdOrSlug := ctx.Query("plan_id_or_slug")
 
 	// Create pagination input
 	paginationInput := pagination.ExtractPaginationFromContext(ctx)
 	c := context.WithValue(ctx.UserContext(), constants.TenantSlugKey, tenantSlug)
+
+	// Validate UUID parameters
+	orgID := ctx.Query("org_id")
+	userID := ctx.Query("user_id")
+
+	if orgID != "" && !validateUUID(orgID) {
+		errResp := domainerrors.NewErrorResponseWithOpts(nil, domainerrors.EINVALID, "invalid organization ID format")
+		h.logger.Error("invalid organization ID format", zap.String("org_id", orgID))
+		return ctx.Status(errResp.Status).JSON(errResp.ToJson())
+	}
+
+	if userID != "" && !validateUUID(userID) {
+		errResp := domainerrors.NewErrorResponseWithOpts(nil, domainerrors.EINVALID, "invalid user ID format")
+		h.logger.Error("invalid user ID format", zap.String("user_id", userID))
+		return ctx.Status(errResp.Status).JSON(errResp.ToJson())
+	}
+
+	// Validate time format parameters
+	if validFrom != "" && !validateTimeFormat(validFrom) {
+		errResp := domainerrors.NewErrorResponseWithOpts(nil, domainerrors.EINVALID, "invalid valid_from timestamp format")
+		h.logger.Error("invalid valid_from timestamp format", zap.String("valid_from", validFrom))
+		return ctx.Status(errResp.Status).JSON(errResp.ToJson())
+	}
+
+	if validUntil != "" && !validateTimeFormat(validUntil) {
+		errResp := domainerrors.NewErrorResponseWithOpts(nil, domainerrors.EINVALID, "invalid valid_until timestamp format")
+		h.logger.Error("invalid valid_until timestamp format", zap.String("valid_until", validUntil))
+		return ctx.Status(errResp.Status).JSON(errResp.ToJson())
+	}
+
+	if validFrom != "" && validUntil != "" && validFrom > validUntil {
+		errResp := domainerrors.NewErrorResponseWithOpts(nil, domainerrors.EINVALID, "valid_from cannot be after valid_until")
+		h.logger.Error("valid_from cannot be after valid_until", zap.Reflect("error", errResp))
+		return ctx.Status(errResp.Status).JSON(errResp.ToJson())
+	}
 
 	if len(ctx.Queries()) == 0 {
 		// Call service to list all assignments
@@ -86,8 +142,8 @@ func (h *httpHandler) list(ctx *fiber.Ctx) error {
 
 	queryAssignments := models.QueryPlanAssignmentInput{
 		PlanID:         planId,
-		OrganizationID: ctx.Query("orgId"),
-		UserID:         ctx.Query("userId"),
+		OrganizationID: ctx.Query("org_id"),
+		UserID:         ctx.Query("user_id"),
 		ValidFrom:      parsedValidFrom,
 		ValidUntil:     parsedValidUntil,
 	}
@@ -116,14 +172,14 @@ func (h *httpHandler) list(ctx *fiber.Ctx) error {
 // @Accept json
 // @Produce json
 // @Param X-Tenant-Slug header string true "Tenant Slug"
-// @Param validFromBefore query string false "Valid from before date (format: YYYY-MM-DDThh:mm:ssZ)"
-// @Param validFromAfter query string false "Valid from after date (format: YYYY-MM-DDThh:mm:ssZ)"
-// @Param validUntilBefore query string false "Valid until before date (format: YYYY-MM-DDThh:mm:ssZ)"
-// @Param validUntilAfter query string false "Valid until after date (format: YYYY-MM-DDThh:mm:ssZ)"
+// @Param valid_from_before query string false "Valid from before date (format: YYYY-MM-DDThh:mm:ssZ)"
+// @Param valid_from_after query string false "Valid from after date (format: YYYY-MM-DDThh:mm:ssZ)"
+// @Param valid_until_before query string false "Valid until before date (format: YYYY-MM-DDThh:mm:ssZ)"
+// @Param valid_until_after query string false "Valid until after date (format: YYYY-MM-DDThh:mm:ssZ)"
 // @Param action query string false "Action type (Create, Update, Delete)"
-// @Param planIdOrSlug query string false "Plan ID or slug"
-// @Param orgId query string false "Organization ID"
-// @Param userId query string false "User ID"
+// @Param plan_id_or_slug query string false "Plan ID or slug"
+// @Param org_id query string false "Organization ID"
+// @Param user_id query string false "User ID"
 // @Param page query int false "Page number"
 // @Param limit query int false "Items per page"
 // @Success 200 {object} models.HttpResponse[pagination.PaginationView[models.PlanAssignmentHistory]] "Assignment history retrieved successfully"
@@ -136,16 +192,57 @@ func (h *httpHandler) listhistory(ctx *fiber.Ctx) error {
 	var genErr error
 	var planId *uuid.UUID
 	var planassignments *pagination.PaginationView[models.PlanAssignmentHistory]
-	validFromBefore := ctx.Query("validFromBefore")
-	validFromAfter := ctx.Query("validFromAfter")
-	validUntilBefore := ctx.Query("validUntilBefore")
-	validUntilAfter := ctx.Query("validUntilAfter")
+	validFromBefore := ctx.Query("valid_from_before")
+	validFromAfter := ctx.Query("valid_from_after")
+	validUntilBefore := ctx.Query("valid_until_before")
+	validUntilAfter := ctx.Query("valid_until_after")
 	action := ctx.Query("action")
-	planIdOrSlug := ctx.Query("planIdOrSlug")
+	planIdOrSlug := ctx.Query("plan_id_or_slug")
 
 	// Create pagination input
 	paginationInput := pagination.ExtractPaginationFromContext(ctx)
 	c := context.WithValue(ctx.UserContext(), constants.TenantSlugKey, tenantSlug)
+
+	// Validate UUID parameters
+	orgID := ctx.Query("org_id")
+	userID := ctx.Query("user_id")
+
+	if orgID != "" && !validateUUID(orgID) {
+		errResp := domainerrors.NewErrorResponseWithOpts(nil, domainerrors.EINVALID, "invalid organization ID format")
+		h.logger.Error("invalid organization ID format", zap.String("org_id", orgID))
+		return ctx.Status(errResp.Status).JSON(errResp.ToJson())
+	}
+
+	if userID != "" && !validateUUID(userID) {
+		errResp := domainerrors.NewErrorResponseWithOpts(nil, domainerrors.EINVALID, "invalid user ID format")
+		h.logger.Error("invalid user ID format", zap.String("user_id", userID))
+		return ctx.Status(errResp.Status).JSON(errResp.ToJson())
+	}
+
+	// Validate time format parameters
+	if validFromBefore != "" && !validateTimeFormat(validFromBefore) {
+		errResp := domainerrors.NewErrorResponseWithOpts(nil, domainerrors.EINVALID, "invalid valid_from_before timestamp format")
+		h.logger.Error("invalid valid_from_before timestamp format", zap.String("valid_from_before", validFromBefore))
+		return ctx.Status(errResp.Status).JSON(errResp.ToJson())
+	}
+
+	if validFromAfter != "" && !validateTimeFormat(validFromAfter) {
+		errResp := domainerrors.NewErrorResponseWithOpts(nil, domainerrors.EINVALID, "invalid valid_from_after timestamp format")
+		h.logger.Error("invalid valid_from_after timestamp format", zap.String("valid_from_after", validFromAfter))
+		return ctx.Status(errResp.Status).JSON(errResp.ToJson())
+	}
+
+	if validUntilBefore != "" && !validateTimeFormat(validUntilBefore) {
+		errResp := domainerrors.NewErrorResponseWithOpts(nil, domainerrors.EINVALID, "invalid valid_until_before timestamp format")
+		h.logger.Error("invalid valid_until_before timestamp format", zap.String("valid_until_before", validUntilBefore))
+		return ctx.Status(errResp.Status).JSON(errResp.ToJson())
+	}
+
+	if validUntilAfter != "" && !validateTimeFormat(validUntilAfter) {
+		errResp := domainerrors.NewErrorResponseWithOpts(nil, domainerrors.EINVALID, "invalid valid_until_after timestamp format")
+		h.logger.Error("invalid valid_until_after timestamp format", zap.String("valid_until_after", validUntilAfter))
+		return ctx.Status(errResp.Status).JSON(errResp.ToJson())
+	}
 
 	if action != "" && !models.ValidateHistoryAction(action) {
 		errResp := domainerrors.NewErrorResponseWithOpts(nil, domainerrors.EINVALID, "provide valid action : Create, Update and Delete")
@@ -200,8 +297,8 @@ func (h *httpHandler) listhistory(ctx *fiber.Ctx) error {
 
 	queryAssignments := models.QueryPlanAssignmentHistoryInput{
 		PlanID:           planId,
-		OrganizationID:   ctx.Query("orgId"),
-		UserID:           ctx.Query("userId"),
+		OrganizationID:   ctx.Query("org_id"),
+		UserID:           ctx.Query("user_id"),
 		Action:           action,
 		ValidFromBefore:  parsedValidFromBefore,
 		ValidFromAfter:   parsedValidFromAfter,

--- a/interfaces/http/routes/v1/assignments/routes.go
+++ b/interfaces/http/routes/v1/assignments/routes.go
@@ -2,15 +2,12 @@ package assignments
 
 import (
 	"context"
-	"time"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
 	"github.com/redcardinal-io/metering/application/services"
-	"github.com/redcardinal-io/metering/domain/models"
 	"github.com/redcardinal-io/metering/domain/pkg/logger"
-	"github.com/redcardinal-io/metering/domain/pkg/pagination"
 )
 
 type httpHandler struct {
@@ -45,21 +42,4 @@ func getPlanIDFromIdentifier(ctx context.Context, idOrSlug string, planSvc *serv
 	}
 
 	return &plan.ID, nil
-}
-
-func getPlanTimeRange(ctx context.Context, planId *uuid.UUID, orgId string, userId string, planSvc *services.PlanManagementService) (*time.Time, *time.Time, error) {
-	assignmentQueryInput := models.QueryPlanAssignmentInput{
-		PlanID:         planId,
-		OrganizationID: orgId,
-		UserID:         userId,
-	}
-	plan, err := planSvc.ListAssignments(ctx, assignmentQueryInput, pagination.Pagination{Limit: 1, Page: 0})
-	if err != nil {
-		return nil, nil, err
-	}
-
-	validFrom := plan.Results[0].ValidFrom
-	validUntil := plan.Results[0].ValidUntil
-
-	return &validFrom, &validUntil, nil
 }

--- a/interfaces/http/routes/v1/plans/list.go
+++ b/interfaces/http/routes/v1/plans/list.go
@@ -52,10 +52,8 @@ func (h *httpHandler) list(ctx *fiber.Ctx) error {
 	paginationInput := pagination.ExtractPaginationFromContext(ctx)
 
 	c := context.WithValue(ctx.UserContext(), constants.TenantSlugKey, tenantSlug)
-	var plans *pagination.PaginationView[models.Plan]
-	var err error
 
-	plans, err = h.planSvc.ListPlans(c, paginationInput)
+	plans, err := h.planSvc.ListPlans(c, paginationInput)
 	if err != nil {
 		h.logger.Error("failed to list plans", zap.Reflect("error", err))
 		errResp := domainerrors.NewErrorResponse(err)

--- a/interfaces/http/routes/v1/plans/list.go
+++ b/interfaces/http/routes/v1/plans/list.go
@@ -12,9 +12,10 @@ import (
 )
 
 type queryPlanParams struct {
-	Page  int    `query:"page" validate:"omitempty,min=1"`
-	Limit int    `query:"limit" validate:"omitempty,min=1,max=100"`
-	Type  string `query:"type" validate:"omitempty,oneof=standard custom"`
+	Page     int    `query:"page" validate:"omitempty,min=1"`
+	Limit    int    `query:"limit" validate:"omitempty,min=1,max=100"`
+	Type     string `query:"type" validate:"omitempty,oneof=standard custom"`
+	Archived bool   `query:"archived" validate:"omitempty"`
 }
 
 // @Summary List all plans
@@ -49,8 +50,6 @@ func (h *httpHandler) list(ctx *fiber.Ctx) error {
 
 	// Create pagination input
 	paginationInput := pagination.ExtractPaginationFromContext(ctx)
-
-	// Add type filter if provided
 
 	c := context.WithValue(ctx.UserContext(), constants.TenantSlugKey, tenantSlug)
 	var plans *pagination.PaginationView[models.Plan]

--- a/interfaces/http/routes/v1/plans/planfeatures/middleware.go
+++ b/interfaces/http/routes/v1/plans/planfeatures/middleware.go
@@ -2,6 +2,7 @@ package planfeatures
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
@@ -66,7 +67,7 @@ func (h *httpHandler) TenantPlanFeatureMiddleware() fiber.Handler {
 
 			if !belongs {
 				errResp := domainerrors.NewErrorResponseWithOpts(
-					nil,
+					fmt.Errorf("plan %s and feature %s do not belong to tenant %s or are not found", planID, featureID, tenantSlug),
 					domainerrors.EUNAUTHORIZED,
 					"plan feature not found or does not belong to tenant",
 				)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation for assignment time ranges during updates, ensuring new dates do not violate existing assignment constraints.
	- Added validation for UUID and timestamp formats in assignment listing endpoints, with enhanced error handling.
- **Tests**
	- Added comprehensive unit tests to verify correct behavior of assignment time range validation.
- **Refactor**
	- Streamlined validation logic by moving time range checks from the API layer to the service layer for better consistency and maintainability.
	- Removed redundant time range validation from the API layer to rely on service-level checks.
- **New Features**
	- Added filtering of plans by archived status in the plans listing endpoint.
- **Bug Fixes**
	- Enhanced error messages to include both custom and underlying error details for clearer feedback.
- **Improvements**
	- Added query parameter validation for plan listing, including pagination, type filtering, and archived status.
	- Updated plan feature queries to filter by tenant and improved configuration data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->